### PR TITLE
Resolves #2: JSX has native support in vscode

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ Alternatively you can open the extensions panel and search for 'React snippets S
 * TypeScript (.ts)
 * JavaScript React (.jsx)
 * TypeScript React (.tsx)
-* JSX after installing the [corresponding extension](https://marketplace.visualstudio.com/items?itemName=TwentyChung.jsx)
 
 ## Snippets
 

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
   "contributes": {
     "snippets": [
       {
-          "language": "javascriptreact",
-          "path": "./snippets/snippets.json"
+        "language": "javascriptreact",
+        "path": "./snippets/snippets.json"
       },
       {
         "language": "javascript",
@@ -35,10 +35,6 @@
       },
       {
         "language": "typescriptreact",
-        "path": "./snippets/snippets.json"
-      },
-      {
-        "language": "jsx",
         "path": "./snippets/snippets.json"
       }
     ]


### PR DESCRIPTION
JSX tags are supported as an embedded language under `javascript react` in vscode since 1.9.0.
The extension previously supported 'jsx' as a distinct language via (https://marketplace.visualstudio.com/items?itemName=TwentyChung.jsx), throwing an error when the extension was not installed.